### PR TITLE
Add option to ignore specific named unused imports

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function( grunt ) {
   'use strict';
 
   grunt.initConfig({
-    
+
     jshint: {
       all: [
         'Gruntfile.js',
@@ -31,16 +31,19 @@ module.exports = function( grunt ) {
       array: [ 'test/array/*-0.js' , 'test/array/*-1.js' ],
       wildcard: 'test/wildcard/*.js',
       default_as: 'test/default_as/*.js',
-      options: { test: true }
+      options: {
+        ignore: [ "something", "$Error", "$_delete" ],
+        test: true
+      }
     },
 
     nodeunit: {
       tests: [ 'test/*(_?)test.js' ]
     }
   });
-  
+
   grunt.loadTasks( 'tasks' );
-  
+
   [
     'grunt-contrib-jshint',
     'grunt-contrib-clean',

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ grunt.initConfig({
 
 ### Options
 
-| Property | Type | Default | Description |
-| -------- | ---- | ------- | ----------- |
+| Property | Type                  | Default | Description |
+| -------- | --------------------- | ------- | ----------- |
 | `force` | `Boolean` | `false` | A boolean value indicating whether grunt should continue if unused imports are detected. |
+| `ignore` | `String` or `Array of String` | `[]` | The name(s) of unused imports to ignore. If ignored unused imports are detected, they will still be reported on with a warning. If *only* ignored unused imports are detected, grunt will continue. |
 | `test` | `Boolean` | `false` | A boolean value indicating whether unit tests should be run. |
 
 ### Usage Examples
@@ -97,4 +98,49 @@ Validating imports in 5 files...
 ]
 
 Warning: found 3 unused imports in 2 files. Use --force to continue.
+```
+
+
+#### Configuration with `ignore` option
+
+```javascript
+grunt.initConfig({
+  'import-clean': {
+    all: 'src/*.js',
+    some: [ 'src/Component.jsx' , 'src/service.js' ],
+    options: {
+      ignore: ['React']  // OR simply ignore: 'React', OR to ignore multiple imports ['React', 'SomethingElse']
+    }
+  },
+});
+```
+
+#### Output with `ignore` option
+
+```shell
+# success (only ignored unused imports found, grunt continues)
+
+Validating imports in 5 files...
+
+"Component.jsx": [
+  "React   (IGNORED)"
+]
+
+Warning: found 1 unused imports in 1 files (1 IGNORED). Use --force to continue.
+```
+
+```shell
+# error (ignored and non-ignored unused imports found, grunt stops)
+
+Validating imports in 5 files...
+
+"Component.jsx": [
+  "React   (IGNORED)",
+  "$_forEach"
+],
+"service.js": [
+  "$_isArray"
+]
+
+Warning: found 3 unused imports in 2 files (1 IGNORED). Use --force to continue.
 ```

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -50,7 +50,8 @@ module.exports = function( grunt ) {
       return file;
     });
 
-    var result = aggregate( files );
+    var importsToIgnore = options.ignore ? ( options.ignore.constructor === Array ? options.ignore : [ options.ignore ] ) : [];
+    var result = aggregate( files, importsToIgnore );
     var msg;
 
     if (options.test) {
@@ -62,13 +63,14 @@ module.exports = function( grunt ) {
 
       print( result.unused );
 
-      msg = 'found ' + result.foundImports +
+      msg = 'found ' + (result.foundImports + result.ignoredImports) +
         ' unused imports in ' + result.foundFiles +
-        ' file' + (result.foundFiles > 1 ? 's' : '') + '.';
+        ' file' + (result.foundFiles > 1 ? 's' : '') +
+        (result.ignoredImports > 0 ? (' (' + result.ignoredImports + ' IGNORED)') : '') + '.';
 
       // grunt.option( 'force' , true ) will force all subsequent tasks.
       // this handles the force option politely.
-      if (options.force) {
+      if (options.force || result.foundImports === 0) {
         console.log(( 'Warning: ' + msg ).yellow );
       }
       else {
@@ -78,6 +80,6 @@ module.exports = function( grunt ) {
     else {
       console.log( '\u2713 OK'.green );
     }
-    
+
   });
 };

--- a/tasks/lib/aggregate.js
+++ b/tasks/lib/aggregate.js
@@ -4,20 +4,35 @@ module.exports = (function() {
 
   var path = require( 'path' );
 
-  return function( files ) {
+  return function( files, importsToIgnore ) {
+
     var result = {
       unused: {},
       totalFiles: files.length,
       foundFiles: 0,
-      foundImports: 0
+      foundImports: 0,
+      ignoredImports: 0
+    };
+
+    var isIgnoredImport = function( unused ) {
+      return importsToIgnore.indexOf(unused) != -1;
+    };
+
+    var reportUnusedImport = function( unused ) {
+      if (isIgnoredImport( unused )) {
+        result.ignoredImports++;
+        return unused + '   (IGNORED)';
+      } else {
+        result.foundImports++;
+        return unused;
+      }
     };
 
     files.forEach(function( file ) {
       var name = path.basename( file.src );
       if (file.unused.length) {
-        result.unused[name] = file.unused;
+        result.unused[name] = file.unused.map(reportUnusedImport);
         result.foundFiles++;
-        result.foundImports += file.unused.length;
       }
     });
 

--- a/test/array/output.json
+++ b/test/array/output.json
@@ -2,9 +2,9 @@
   "unused": {
     "array-0.js": [
       "E$",
-      "something",
-      "$Error",
-      "$_delete",
+      "something   (IGNORED)",
+      "$Error   (IGNORED)",
+      "$_delete   (IGNORED)",
       "$_is",
       "$_indexOf",
       "$_forEach"
@@ -15,5 +15,6 @@
   },
   "totalFiles": 2,
   "foundFiles": 2,
-  "foundImports": 8
+  "foundImports": 5,
+  "ignoredImports": 3
 }

--- a/test/basic/output.json
+++ b/test/basic/output.json
@@ -2,9 +2,9 @@
   "unused": {
     "basic.js": [
       "E$",
-      "something",
-      "$Error",
-      "$_delete",
+      "something   (IGNORED)",
+      "$Error   (IGNORED)",
+      "$_delete   (IGNORED)",
       "$_is",
       "$_indexOf",
       "$_forEach"
@@ -12,5 +12,6 @@
   },
   "totalFiles": 1,
   "foundFiles": 1,
-  "foundImports": 7
+  "foundImports": 4,
+  "ignoredImports": 3
 }

--- a/test/default_as/output.json
+++ b/test/default_as/output.json
@@ -2,11 +2,11 @@
   "unused": {
     "default_as.js": [
       "E$",
-      "something",
+      "something   (IGNORED)",
       "$Class",
       "getPrototype",
-      "$Error",
-      "$_delete",
+      "$Error   (IGNORED)",
+      "$_delete   (IGNORED)",
       "$_is",
       "$_indexOf",
       "$_forEach"
@@ -14,5 +14,6 @@
   },
   "totalFiles": 1,
   "foundFiles": 1,
-  "foundImports": 9
+  "foundImports": 6,
+  "ignoredImports": 3
 }

--- a/test/empty/output.json
+++ b/test/empty/output.json
@@ -2,5 +2,6 @@
   "unused": {},
   "totalFiles": 0,
   "foundFiles": 0,
-  "foundImports": 0
+  "foundImports": 0,
+  "ignoredImports": 0
 }

--- a/test/multi/output.json
+++ b/test/multi/output.json
@@ -2,9 +2,9 @@
   "unused": {
     "multi-0.js": [
       "E$",
-      "something",
-      "$Error",
-      "$_delete",
+      "something   (IGNORED)",
+      "$Error   (IGNORED)",
+      "$_delete   (IGNORED)",
       "$_is",
       "$_indexOf",
       "$_forEach"
@@ -15,5 +15,6 @@
   },
   "totalFiles": 2,
   "foundFiles": 2,
-  "foundImports": 8
+  "foundImports": 5,
+  "ignoredImports": 3
 }

--- a/test/test.js
+++ b/test/test.js
@@ -34,8 +34,8 @@
 
       test.expect( 1 );
 
-      var actual = grunt.file.read( 'tmp/multi.json' );
-      var expected = grunt.file.read( 'test/multi/output.json' );
+      var actual = grunt.file.read( 'tmp/empty.json' );
+      var expected = grunt.file.read( 'test/empty/output.json' );
       test.equal( actual , expected , 'should describe empty behavior.' );
 
       test.done();
@@ -77,22 +77,3 @@
   };
 
 }());
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/wildcard/output.json
+++ b/test/wildcard/output.json
@@ -2,9 +2,9 @@
   "unused": {
     "wildcard.js": [
       "E$",
-      "something",
-      "$Error",
-      "$_delete",
+      "something   (IGNORED)",
+      "$Error   (IGNORED)",
+      "$_delete   (IGNORED)",
       "$_is",
       "$_indexOf",
       "$_forEach"
@@ -12,5 +12,6 @@
   },
   "totalFiles": 1,
   "foundFiles": 1,
-  "foundImports": 7
+  "foundImports": 4,
+  "ignoredImports": 3
 }


### PR DESCRIPTION
I'm adding this feature because it was needed in my usecase, which is running the task on pre-transpiled react JSX code. In such code there are imports of the react core library:

```
import React from 'react';
```

The `React` variable is not referenced in the JSX code, however it _is_ required in the JS code which is ultimately transpiled from the JSX.

Therefore, I know in advance that I want to ignore all unused `React` imports in my code, and have grunt continue when these are found, i.e. not have them break the build.

The existing force: true option does support this, in a very broad way, but allowing me to ignore essentially all unused imports, but it does mean I have to check the warning report on every build to see if any genuinely unused imports have crept in. 

I think it's better to be able to ignore just the `React` imports which I know are fine (or any others for that matter), whilst still breaking the build on all other unused imports - that's what this new option does.

All tests updated by the way - I've simply specified a few of the existing imports in the tests to be ignored, then checked that the counts are ok (I've added a new count for unusedImports which is separate from the existing foundImports count - I've treated foundImports to mean imports which are found and NOT ignored so the total unused imports is the sum of those two counts) and that the report clearly reports on the (IGNORED) unused imports.
